### PR TITLE
Show GitHub error messages when connection fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ public/
 
 # Logs and databases #
 ######################
-*.log
 *.sql
 *.sqlite
 

--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,5 @@ pipeline/build/
 
 /*.js 
 !index.js
-constants
-utils
+/constants
+/utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,6 +1974,16 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "main": "index.js",
   "scripts": {
     "build": "babel src --out-dir . --ignore src/__tests__,src/__fixtures__",
-    "test": "NODE_ENV=test jest __tests__ --env=node",
-    "test:watch": "NODE_ENV=test jest __tests__ --watch --env=node",
+    "test": "cross-env NODE_ENV=test jest __tests__ --env=node",
+    "test:watch": "cross-env NODE_ENV=test jest __tests__ --watch --env=node",
     "test:lint": "eslint --env node --ext .js src",
     "prettier": "prettier --write '{./,__{tests,mocks}__}/**/*.+(js|jsx)'",
     "prepare": "npm run test && npm run test:lint -- --fix && npm run build",
@@ -53,6 +53,7 @@
     "@babel/preset-env": "^7.4.5",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.8.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-defaults": "^9.0.0",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -3,7 +3,7 @@ Copyright 2019 Province of British Columbia
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at 
+You may obtain a copy of the License at
 
    http://www.apache.org/licenses/LICENSE-2.0
 
@@ -16,29 +16,34 @@ limitations under the License.
 Created by Patrick Simonian
 */
 import fetch from 'node-fetch';
+
 /**
  * Fetches contents from file
  * note the media type header, it converts what would have been a
  * b64 encoded string of the file contents into either raw string data or json
  * @param {String} path
  * @param {String} token
- * @param {Object} boundProperties and object properties you want to bind to returned json
  */
 export const fetchFile = async (path, token) => {
-  try {
-    const result = await fetch(path, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
-      },
-    });
-    const data = await result.json();
-    if (result.ok) return data;
-  } catch (e) {
-    return undefined;
+  const result = await fetch(path, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Media-Type': 'Accept: application/vnd.github.v3.raw+json',
+    },
+  });
+  const data = await result.json();
+  if (!result.ok) {
+    throw new Error(
+      `Error querying GitHub: ${result.status} ${result.statusText}\n${JSON.stringify(
+        data,
+        null,
+        4,
+      )}`,
+    );
   }
-  return undefined;
+
+  return data;
 };
 
 /**


### PR DESCRIPTION
## Summary
Show GitHub error messages when connection fails.

## Notable Changes
If an error occurs while consuming the GitHub API, a detailed red message is shown, e.g.

> Error querying GitHub: 401 Unauthorized
>
> {
>   "message": "Bad credentials",
>   "documentation_url": "https://developer.github.com/v3"
> }
Otherwise, if the connection fails, the user is only informed by the transformer instead of this plugin.

## Minor Changes
- npm build now works on Windows
- .gitignore doesn't exclude actual source code directory 'utils'